### PR TITLE
Disable users on vacation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .bundle
 log
 .env
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'time_ago_in_words'
 gem 'wannabe_bool'
 
 group :development, :test do
+  gem 'byebug'
   gem 'foreman'
   gem 'rake', '~> 10.4'
   gem 'rubocop', '0.49.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     bson (4.2.2)
     builder (3.2.3)
+    byebug (9.0.6)
     capybara (2.15.1)
       addressable
       mini_mime (>= 0.1.3)
@@ -272,6 +273,7 @@ PLATFORMS
 
 DEPENDENCIES
   ambit
+  byebug
   capybara
   chronic
   database_cleaner
@@ -305,4 +307,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/slack-sup/models/team.rb
+++ b/slack-sup/models/team.rb
@@ -142,13 +142,7 @@ class Team
   def sync!
     client = Slack::Web::Client.new(token: token)
     members = client.paginate(:users_list, presence: false).map(&:members).flatten
-    humans = members.select do |member|
-      !member.is_bot &&
-        !member.deleted &&
-        !member.is_restricted &&
-        !member.is_ultra_restricted &&
-        member.id != 'USLACKBOT'
-    end.map do |member|
+    humans = members.select { |member| active_member?(member) }.map do |member|
       existing_user = User.where(user_id: member.id).first
       existing_user ||= User.new(user_id: member.id, team: self)
       existing_user.user_name = member.name
@@ -180,6 +174,19 @@ class Team
   end
 
   private
+
+  def active_member?(member)
+    !member.is_bot &&
+      !member.deleted &&
+      !member.is_restricted &&
+      !member.is_ultra_restricted &&
+      !on_vacation?(member) &&
+      member.id != 'USLACKBOT'
+  end
+
+  def on_vacation?(member)
+    [member.name, member.real_name, member.profile.status_text].join =~ /(ooo|vacationing)/i
+  end
 
   def validate_team_field_label
     return unless team_field_label && team_field_label_changed?

--- a/slack-sup/models/team.rb
+++ b/slack-sup/models/team.rb
@@ -185,7 +185,7 @@ class Team
   end
 
   def on_vacation?(member)
-    [member.name, member.real_name, member.profile.status_text].join =~ /(ooo|vacationing)/i
+    [member.name, member.real_name, member&.profile&.status_text].compact.join =~ /(ooo|vacationing)/i
   end
 
   def validate_team_field_label


### PR DESCRIPTION
# Feature
We want to disable user's who are currently on OOO for current round of SUP.

Fixes #1 

# Solution
Added new private `on_vacation?` method to `Team` which checks slack member's `name`, `real_name` and `profile.status_text` for words `ooo` or `vacationing` and based on that will remove them from current round.

PS. added `byebug` to `test` and `development`.