### PR TITLE
Rename Team.last_sup to Team.last_round #minor #refactor

### DIFF
--- a/slack-sup/app.rb
+++ b/slack-sup/app.rb
@@ -33,8 +33,8 @@ module SlackSup
     def ask!
       Team.active.each do |team|
         begin
-          last_sup_at = team.last_sup_at
-          logger.info "Checking #{team}, #{last_sup_at ? 'last sup ' + last_sup_at.ago_in_words : 'first time sup'}."
+          last_round_at = team.last_round_at
+          logger.info "Checking #{team}, #{last_round_at ? 'last round ' + last_round_at.ago_in_words : 'first time sup'}."
           round = team.ask!
           logger.info "Asked about previous sup round #{round}." if round
         rescue StandardError => e

--- a/slack-sup/models/team.rb
+++ b/slack-sup/models/team.rb
@@ -79,19 +79,19 @@ class Team
   end
 
   def ask!
-    sup = last_sup
-    return unless sup && sup.ask?
-    sup.ask!
-    sup
+    round = last_round
+    return unless round && round.ask?
+    round.ask!
+    round
   end
 
-  def last_sup
+  def last_round
     rounds.desc(:created_at).first
   end
 
-  def last_sup_at
-    sup = last_sup
-    sup ? sup.created_at : nil
+  def last_round_at
+    round = last_round
+    round ? round.created_at : nil
   end
 
   def sup_time_of_day_s
@@ -123,7 +123,7 @@ class Team
     return false if now_in_tz < now_in_tz.beginning_of_day + sup_time_of_day
     # don't sup more than once a week
     time_limit = Time.now.utc - sup_every_n_weeks.weeks
-    (last_sup_at || time_limit) <= time_limit
+    (last_round_at || time_limit) <= time_limit
   end
 
   def inform!(message)


### PR DESCRIPTION
While looking at flow for how to config when to ask for sup results, got confused a little with `team.last_sup` returns last `round`, while i think data-wise probably last round and last sup would have the same date, but since we have `Sup` model it was little confusing, did some renaming there. Let me know if it was intentional and you want to keep it the old way.