### PR TITLE
Configurable followup day

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,12 +32,12 @@ Metrics/AbcSize:
 # Offense count: 77
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 443
+  Max: 467
 
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 323
+  Max: 338
 
 # Offense count: 8
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,7 +32,7 @@ Metrics/AbcSize:
 # Offense count: 77
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 467
+  Max: 477
 
 # Offense count: 3
 # Configuration parameters: CountComments.

--- a/slack-sup/api/presenters/team_presenter.rb
+++ b/slack-sup/api/presenters/team_presenter.rb
@@ -15,6 +15,7 @@ module Api
       property :created_at, type: DateTime, desc: 'Date/time when the team was created.'
       property :updated_at, type: DateTime, desc: 'Date/time when the team was updated.'
       property :sup_wday, type: Integer, desc: "S'Up day of the week."
+      property :sup_followup_wday, type: Integer, desc: "Ask for S'up result day of week."
       property :sup_day, type: String, desc: "S'Up day of the week in English."
       property :sup_tz, type: String, desc: 'Team timezone.'
       property :sup_time_of_day, type: String, desc: "Earliest time of day for a S'Up in seconds."

--- a/slack-sup/app.rb
+++ b/slack-sup/app.rb
@@ -33,8 +33,8 @@ module SlackSup
     def ask!
       Team.active.each do |team|
         begin
-          last_sup_at = team.last_sup_at
-          logger.info "Checking #{team}, #{last_sup_at ? 'last sup ' + last_sup_at.ago_in_words : 'first time sup'}."
+          last_round_at = team.last_round_at
+          logger.info "Checking #{team}, #{last_round_at ? 'last round ' + last_round_at.ago_in_words : 'first time sup'}."
           round = team.ask!
           logger.info "Asked about previous sup round #{round}." if round
         rescue StandardError => e

--- a/slack-sup/commands/help.rb
+++ b/slack-sup/commands/help.rb
@@ -21,22 +21,23 @@ module SlackSup
 
         Team Admins
         -----------
-        set size [number]         - set the number of people for each S'Up, default is 3
-        set day [day of week]     - set the day to S'Up, default is Monday
-        set time [time of day]    - set the earliest time to S'Up, default is 9 AM
-        set timezone [tz]         - set team timezone, default is Eastern Time (US & Canada)
-        set weeks [number]        - set the number of weeks between S'Up, default is 1
-        set recency [number]      - set the number of weeks during which to avoid pairing the same people, default is 12
-        set api [on|off]          - enable/disable API access to your team data
-        set api token             - require an access token in the X-Access-Token header for API access
-        unset api token           - don't require an access token for API access
-        rotate api token          - rotate the token required for API access
-        set team field [name]     - set the name of the custom profile team field (users in the same team don't meet)
-        unset team field          - unset the name of the custom profile team field
-        set message [message]     - set the message users see when creating a S'Up DM
-        unset message             - reset the message users see when creating a S'Up DM to the default one
-        opt [in|out] [@mention]   - opt a user in/out of S'Up by @mention
-        subscription              - show team subscription info
+        set size [number]          - set the number of people for each S'Up, default is 3
+        set day [day of week]      - set the day to S'Up, default is Monday
+        set time [time of day]     - set the earliest time to S'Up, default is 9 AM
+        set timezone [tz]          - set team timezone, default is Eastern Time (US & Canada)
+        set weeks [number]         - set the number of weeks between S'Up, default is 1
+        set followup [day of week] - set the follow up day of S'up, default is Thursday
+        set recency [number]       - set the number of weeks during which to avoid pairing the same people, default is 12
+        set api [on|off]           - enable/disable API access to your team data
+        set api token              - require an access token in the X-Access-Token header for API access
+        unset api token            - don't require an access token for API access
+        rotate api token           - rotate the token required for API access
+        set team field [name]      - set the name of the custom profile team field (users in the same team don't meet)
+        unset team field           - unset the name of the custom profile team field
+        set message [message]      - set the message users see when creating a S'Up DM
+        unset message              - reset the message users see when creating a S'Up DM to the default one
+        opt [in|out] [@mention]    - opt a user in/out of S'Up by @mention
+        subscription               - show team subscription info
 
         More information at https://sup.playplay.io
         ```

--- a/slack-sup/models/round.rb
+++ b/slack-sup/models/round.rb
@@ -22,7 +22,7 @@ class Round
 
   def ask?(dt = 3.days)
     return false if asked_at
-    ran_at && ran_at + dt <= Time.now.utc
+    ran_at && ran_at <= dt.ago
   end
 
   def ask!

--- a/slack-sup/models/round.rb
+++ b/slack-sup/models/round.rb
@@ -20,9 +20,9 @@ class Round
     "id=#{id}, #{team}"
   end
 
-  def ask?(dt = 3.days)
+  def ask?
     return false if asked_at
-    ran_at && ran_at <= dt.ago
+    Time.now.wday == team.sup_followup_wday
   end
 
   def ask!

--- a/slack-sup/models/team.rb
+++ b/slack-sup/models/team.rb
@@ -79,19 +79,19 @@ class Team
   end
 
   def ask!
-    sup = last_sup
-    return unless sup && sup.ask?
-    sup.ask!
-    sup
+    round = last_round
+    return unless round && round.ask?
+    round.ask!
+    round
   end
 
-  def last_sup
+  def last_round
     rounds.desc(:created_at).first
   end
 
-  def last_sup_at
-    sup = last_sup
-    sup ? sup.created_at : nil
+  def last_round_at
+    round = last_round
+    round ? round.created_at : nil
   end
 
   def sup_time_of_day_s
@@ -123,7 +123,7 @@ class Team
     return false if now_in_tz < now_in_tz.beginning_of_day + sup_time_of_day
     # don't sup more than once a week
     time_limit = Time.now.utc - sup_every_n_weeks.weeks
-    (last_sup_at || time_limit) <= time_limit
+    (last_round_at || time_limit) <= time_limit
   end
 
   def inform!(message)

--- a/slack-sup/models/team.rb
+++ b/slack-sup/models/team.rb
@@ -14,6 +14,8 @@ class Team
   field :sup_recency, type: Integer, default: 12
   # sup day of the week, defaults to Monday
   field :sup_wday, type: Integer, default: 1
+  # sup day of the week we ask for sup results, defaults to Thursday
+  field :sup_followup_wday, type: Integer, default: 4
   field :sup_tz, type: String, default: 'Eastern Time (US & Canada)'
   validates_presence_of :sup_tz
 
@@ -80,7 +82,7 @@ class Team
 
   def ask!
     round = last_round
-    return unless round && round.ask?
+    return unless round && round.ask?(sup_followup_wday.days)
     round.ask!
     round
   end
@@ -108,6 +110,10 @@ class Team
 
   def sup_day
     Date::DAYNAMES[sup_wday]
+  end
+
+  def sup_followup_day
+    Date::DAYNAMES[sup_followup_wday]
   end
 
   def sup_tzone

--- a/spec/models/round_spec.rb
+++ b/spec/models/round_spec.rb
@@ -156,18 +156,25 @@ describe Round do
       it 'is false immediately after the round' do
         expect(round.ask?).to be false
       end
-      context 'after more than three days' do
-        before do
-          Timecop.travel(Time.now.utc + 4.days)
+      context 'have not asked already' do
+        it 'is true for Thursday day of the week' do
+          Timecop.travel(Time.now - Time.now.wday.days + 4.days)
+          expect(round.ask?).to be true
         end
-        it 'is true' do
+        it 'is false for Wednesday' do
+          Timecop.travel(Time.now - Time.now.wday.days + 3.days)
+          expect(round.ask?).to be false
+        end
+        it 'is true for Wednesday when team.followup_day is 3' do
+          team.update_attributes!(sup_followup_wday: 3)
+          Timecop.travel(Time.now - Time.now.wday.days + 3.days)
           expect(round.ask?).to be true
         end
       end
-      context 'after more than three days and already asked' do
+      context 'on Thursday days and already asked' do
         before do
           round.update_attributes!(asked_at: Time.now.utc)
-          Timecop.travel(Time.now.utc + 4.days)
+          Timecop.travel(Time.now - Time.now.wday.days + 4.days)
         end
         it 'is false' do
           expect(round.ask?).to be false

--- a/spec/slack-sup/commands/set_spec.rb
+++ b/spec/slack-sup/commands/set_spec.rb
@@ -416,6 +416,16 @@ describe SlackSup::Commands::Set, vcr: { cassette_name: 'user_info' } do
           "Team S'Up is every week."
         )
       end
+      it 'cannot set followup day' do
+        expect(message: "#{SlackRubyBot.config.user} set followup 2").to respond_with_slack_message(
+          "Team S'Up followup day is on Thursday. Only a Slack team admin can change that, sorry."
+        )
+      end
+      it 'can see followup day' do
+        expect(message: "#{SlackRubyBot.config.user} set followup").to respond_with_slack_message(
+          "Team S'Up followup day is on Thursday."
+        )
+      end
       it 'cannot set recency' do
         expect(message: "#{SlackRubyBot.config.user} set recency 2").to respond_with_slack_message(
           'Taking special care to not pair the same people more than every 12 weeks. Only a Slack team admin can change that, sorry.'

--- a/spec/slack-sup/commands/set_spec.rb
+++ b/spec/slack-sup/commands/set_spec.rb
@@ -138,6 +138,30 @@ describe SlackSup::Commands::Set, vcr: { cassette_name: 'user_info' } do
         )
       end
     end
+    context 'followup' do
+      it 'defaults to Thursday' do
+        expect(message: "#{SlackRubyBot.config.user} set followup").to respond_with_slack_message(
+          "Team S'Up followup day is on Thursday."
+        )
+      end
+      it 'shows current value of sup followup' do
+        team.update_attributes!(sup_followup_wday: 2)
+        expect(message: "#{SlackRubyBot.config.user} set followup").to respond_with_slack_message(
+          "Team S'Up followup day is on Tuesday."
+        )
+      end
+      it 'changes followup' do
+        expect(message: "#{SlackRubyBot.config.user} set followup friday").to respond_with_slack_message(
+          "Team S'Up followup day is now on Friday."
+        )
+        expect(team.reload.sup_followup_wday).to eq 5
+      end
+      it 'errors set on an invalid day' do
+        expect(message: "#{SlackRubyBot.config.user} set followup foobar").to respond_with_slack_message(
+          "Day _foobar_ is invalid, try _Monday_, _Tuesday_, etc. Team S'Up followup day is on Thursday."
+        )
+      end
+    end
     context 'time' do
       it 'defaults to 9AM' do
         expect(message: "#{SlackRubyBot.config.user} set time").to respond_with_slack_message(


### PR DESCRIPTION
# Problem
Currently follow up message is hardcoded to be sent on every Thursday, we need to make it configurable. 

fixes https://github.com/dblock/slack-sup/issues/44

# Solution
Followed the same pattern as `sup_wday`, added a new `sup_followup_wday` field to `Team` which by default is set to 4 (Thursdays).
Added new `set followup` command which can set `sup_followup_wday` for the team by admin.

## Question
wasn't sure if we want any type of validation on `sup_followup_wday` originally i thought it should be after `sup_wday` but that doesn't make sense if we want to send sup message on Thursday and followup on Monday for example. Let me know what you think.